### PR TITLE
Feature/remove stash cmd

### DIFF
--- a/zsh/oh-my-zsh.sls
+++ b/zsh/oh-my-zsh.sls
@@ -5,16 +5,14 @@
 {%- set home = user.get('home', "/home/%s" % name) %}
 
 oh_my_zsh_{{ name }}:
-  cmd.run:
-    - name: /usr/bin/git stash
-    - cwd: {{ home }}/.oh-my-zsh
-    - onlyif: test -d {{ home }}/.oh-my-zsh
   git.latest:
     - name: git://github.com/robbyrussell/oh-my-zsh.git
     - rev: master
     - target: {{ home }}/.oh-my-zsh
     - require:
       - pkg: zsh
+    - depth: 1
+    - force_checkout: true
   file.directory:
     - name: {{ home }}/.oh-my-zsh
     - dir_mode: 755

--- a/zsh/oh-my-zsh.sls
+++ b/zsh/oh-my-zsh.sls
@@ -13,17 +13,8 @@ oh_my_zsh_{{ name }}:
       - pkg: zsh
     - depth: 1
     - force_checkout: true
-  file.directory:
-    - name: {{ home }}/.oh-my-zsh
-    - dir_mode: 755
-    - file_mode: 755
+    - force_clone: true
     - user: {{ name }}
-    - group: {{ name }}
-    - recurse:
-      - mode
-      - user
-      - group
-    - require:
-      - git: oh_my_zsh_{{ name }}
+
 
 {% endfor %}


### PR DESCRIPTION
it looks like force_checkout does the trick. also we can specify the user the git clone-command is running as which makes the file.directory-entry obsolete
